### PR TITLE
Use correct case for required package name.

### DIFF
--- a/VeraCrypt/VeraCrypt.munki.recipe
+++ b/VeraCrypt/VeraCrypt.munki.recipe
@@ -48,7 +48,7 @@
 					<string>IDRIX</string>
 					<key>requires</key>
 					<array>
-						<string>OSXFUSE</string>
+						<string>osxfuse</string>
 					</array>
 				</dict>
 			</dict>


### PR DESCRIPTION
@48kRAM-recipes/blob/master/OSXFUSE/osxfuse.munki.recipe uses lowercase for the package name. This change allows the VeraCrypt requires key to work without having to change the other package.