### PR TITLE
Update VeraCrypt.download.recipe

### DIFF
--- a/VeraCrypt/VeraCrypt.download.recipe
+++ b/VeraCrypt/VeraCrypt.download.recipe
@@ -32,6 +32,8 @@
 			<dict>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
+				<key>CHECK_FILESIZE_ONLY</key>
+				<string>TRUE</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
I've noticed that VeraCrypt.download.recipe will re-download the installer even when nothing has changed. Looking into a bit, it appears that different etags are returned depending on what SourceForge mirror you're randomly connected to. For example, running the command three times in a row downloaded the installer twice:

```
$ autopkg run VeraCrypt.download.recipe -v
Processing VeraCrypt.download.recipe...
SourceForgeURLProvider
SourceForgeURLProvider: File URL https://sourceforge.net/projects/veracrypt/files/VeraCrypt%201.19/VeraCrypt_1.19.dmg/download
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing <snip>/com.github.andrewvalentine.download.VeraCrypt/downloads/VeraCrypt.dmg
EndOfCheckPhase
Receipt written to <snip>/com.github.andrewvalentine.download.VeraCrypt/receipts/VeraCrypt.download-receipt-20170317-134900.plist

Nothing downloaded, packaged or imported.
```

```
$ autopkg run VeraCrypt.download.recipe -v
Processing VeraCrypt.download.recipe...
SourceForgeURLProvider
SourceForgeURLProvider: File URL https://sourceforge.net/projects/veracrypt/files/VeraCrypt%201.19/VeraCrypt_1.19.dmg/download
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 17 Oct 2016 18:00:16 GMT
URLDownloader: Storing new ETag header: "8bbace-53f135923cc00"
URLDownloader: Downloaded <snip>/com.github.andrewvalentine.download.VeraCrypt/downloads/VeraCrypt.dmg
EndOfCheckPhase
Receipt written to <snip>/com.github.andrewvalentine.download.VeraCrypt/receipts/VeraCrypt.download-receipt-20170317-134905.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    <snip>/com.github.andrewvalentine.download.VeraCrypt/downloads/VeraCrypt.dmg  
```

```
$ autopkg run VeraCrypt.download.recipe -v
Processing VeraCrypt.download.recipe...
SourceForgeURLProvider
SourceForgeURLProvider: File URL https://sourceforge.net/projects/veracrypt/files/VeraCrypt%201.19/VeraCrypt_1.19.dmg/download
URLDownloader
URLDownloader: Storing new Last-Modified header: Mon, 17 Oct 2016 18:00:16 GMT
URLDownloader: Storing new ETag header: "580511b0-8bbace"
URLDownloader: Downloaded <snip>/com.github.andrewvalentine.download.VeraCrypt/downloads/VeraCrypt.dmg
EndOfCheckPhase
Receipt written to <snip>/com.github.andrewvalentine.download.VeraCrypt/receipts/VeraCrypt.download-receipt-20170317-135149.plist

The following new items were downloaded:
    Download Path                                                                                              
    -------------                                                                                              
    <snip>/com.github.andrewvalentine.download.VeraCrypt/downloads/VeraCrypt.dmg  
```

You can see in the last two runs that different etags were returned.

This patch does a quick and dirty workaround by using [CURLDownloader](https://github.com/autopkg/autopkg/wiki/Processor-CURLDownloader)'s CHECK_FILESIZE_ONLY option, which appears to have been designed just for this kind of problem.