### PR TITLE
Update Etcher.download.recipe

### DIFF
--- a/Etcher/Etcher.download.recipe
+++ b/Etcher/Etcher.download.recipe
@@ -8,7 +8,7 @@
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>Etcher</string>
+		<string>balenaEtcher</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -44,9 +44,9 @@
 			<key>Arguments</key>
 				<dict>
 					<key>input_path</key>
-					<string>%pathname%/Etcher.app</string>
+					<string>%pathname%/balenaEtcher.app</string>
 					<key>requirement</key>
-					<string>identifier "io.resin.etcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "66H43P8FRG"</string>
+					<string>identifier "io.balena.etcher" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "66H43P8FRG"</string>
 				</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
It seems that they're pushing on with changes after the Resin.io rebrand and they're now altering the name of the download DMG and app bundle. I've tested these changes locally and they seem to now download the latest version (your current recipe seems to grab 1.4.4) but please test as I'm pretty new to AutoPKG recipes.