### PR TITLE
Update Etcher.download.recipe

### DIFF
--- a/Etcher/Etcher.download.recipe
+++ b/Etcher/Etcher.download.recipe
@@ -19,6 +19,8 @@
 			<string>GitHubReleasesInfoProvider</string>
 			<key>Arguments</key>
 			<dict>
+				<key>include_prereleases</key>
+				<string>true</string>
 				<key>asset_regex</key>
 				<string>%NAME%-[\S]+\.dmg</string>
 				<key>github_repo</key>


### PR DESCRIPTION
With the recent rebranding from Etcher to balenaEtcher, there are no current releases (only pre-releases) with the new naming format. Until a release happens, this download recipe is broken with the current regex. Either the regex could be updated, or the proposed changes could be put in place and then removed after the first release. I'll leave that up to you to decide.

`Error in local.munki.autopkg_Etcher: Processor: GitHubReleasesInfoProvider: Error: No release assets were found that satisfy the criteria.`