### PR TITLE
Update Sloth.download.recipe

### DIFF
--- a/Sloth/Sloth.download.recipe
+++ b/Sloth/Sloth.download.recipe
@@ -21,6 +21,8 @@
 			<dict>
 				<key>github_repo</key>
 				<string>sveinbjornt/Sloth</string>
+				<key>asset_regex</key>
+                                <string>^((?!src).)*$</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Sloth/Sloth.download.recipe
+++ b/Sloth/Sloth.download.recipe
@@ -50,7 +50,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
 				<key>requirement</key>
-				<string>identifier "org.sveinbjorn.Sloth" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: sveinbjornt@gmail.com (55GP2M789L)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
+				<string>anchor apple generic and identifier "org.sveinbjorn.Sloth" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5WX26Y89JP")</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
As the developer sometimes includes the .zip source file in the releases, this regex will omit downloading files that include _src_ in the name.