### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/DetectX/DetectX.munki.recipe
+++ b/DetectX/DetectX.munki.recipe
@@ -45,7 +45,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX.app</string>
 				<key>requires</key>
 				<string>anchor apple generic and identifier "com.sqwarq.DetectX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MAJ5XBJSG3)</string>
 			</dict>
@@ -56,7 +56,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>

--- a/Discord/Discord.install.recipe
+++ b/Discord/Discord.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 					<dict>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Discord.app</string>
 						<key>destination_path</key>
 						<string>/Applications</string>
 					</dict>

--- a/Etcher/Etcher.install.recipe
+++ b/Etcher/Etcher.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 					<dict>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>balenaEtcher.app</string>
 						<key>destination_path</key>
 						<string>/Applications</string>
 					</dict>

--- a/FBMacMessenger/FBMacMessenger.download.recipe
+++ b/FBMacMessenger/FBMacMessenger.download.recipe
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Messenger.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2JS2795PX7"</string>
 			</dict>

--- a/FBMacMessenger/FBMacMessenger.install.recipe
+++ b/FBMacMessenger/FBMacMessenger.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Messenger.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Messenger.app</string>
 			</dict>
 		</dict>
 	</array>

--- a/FBMacMessenger/FBMacMessenger.pkg.recipe
+++ b/FBMacMessenger/FBMacMessenger.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/Messenger.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Messenger.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Messenger.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/Franz/Franz.download.recipe
+++ b/Franz/Franz.download.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Franz.app</string>
 				<key>requirement</key>
 				<string>identifier "com.meetfranz.franz" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = TAC9P63ANZ</string>
 			</dict>

--- a/Franz/Franz.install.recipe
+++ b/Franz/Franz.install.recipe
@@ -31,7 +31,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Franz.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Ghostlab3/Ghostlab3.download.recipe
+++ b/Ghostlab3/Ghostlab3.download.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Ghostlab3.app</string>
 				<key>requirement</key>
 				<string>identifier "com.vanamco.Ghostlab3.www" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LXJYPFT25V</string>
 			</dict>

--- a/Ghostlab3/Ghostlab3.install.recipe
+++ b/Ghostlab3/Ghostlab3.install.recipe
@@ -22,9 +22,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Ghostlab3.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Ghostlab3.app</string>
 			</dict>
 		</dict>
 	</array>

--- a/Ghostlab3/Ghostlab3.munki.recipe
+++ b/Ghostlab3/Ghostlab3.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Ghostlab3.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>

--- a/Gitter/Gitter.download.recipe
+++ b/Gitter/Gitter.download.recipe
@@ -40,7 +40,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Gitter.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "com.troupe.gitter.mac.Gitter" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = A86QBWJ43W)</string>
 			</dict>

--- a/Gitter/Gitter.pkg.recipe
+++ b/Gitter/Gitter.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Gitter.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Gitter.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Gitter.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/Hancock/Hancock.download.recipe
+++ b/Hancock/Hancock.download.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Hancock.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.GroundControl.Hancock" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SWD2B88S58)</string>
 			</dict>

--- a/Hancock/Hancock.install.recipe
+++ b/Hancock/Hancock.install.recipe
@@ -31,7 +31,7 @@
 						<key>destination_path</key>
 						<string>/Applications/</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Hancock.app</string>
 					</dict>
 				</array>
 			</dict>

--- a/Hyper/Hyper.download.recipe
+++ b/Hyper/Hyper.download.recipe
@@ -39,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Hyper.app</string>
 				<key>requirement</key>
 				<string>identifier "co.zeit.hyper" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = JW6Y669B67</string>
 				<key>strict_verification</key>

--- a/Hyper/Hyper.install.recipe
+++ b/Hyper/Hyper.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Hyper.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Hyper.app</string>
 				<key>overwrite</key>
 				<string>true</string>
 			</dict>

--- a/JavaDecompiler-GUI/JD-GUI.install.recipe
+++ b/JavaDecompiler-GUI/JD-GUI.install.recipe
@@ -26,7 +26,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/jd-gui-osx-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/jd-gui-osx-%version%/JD-GUI.app</string>
 				<key>destination_path</key>
 				<string>/Applications/JD-GUI.app</string>
 			</dict>

--- a/KnockKnock/KnockKnock.download.recipe
+++ b/KnockKnock/KnockKnock.download.recipe
@@ -57,7 +57,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/KnockKnock.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.objective-see.KnockKnock" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = VBG97UB4TA)</string>
 			</dict>

--- a/KnockKnock/KnockKnock.install.recipe
+++ b/KnockKnock/KnockKnock.install.recipe
@@ -22,9 +22,9 @@
 				<key>Arguments</key>
 				<dict>
 					<key>source_path</key>
-					<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%/KnockKnock.app</string>
 					<key>destination_path</key>
-					<string>/Applications/%NAME%.app</string>
+					<string>/Applications/KnockKnock.app</string>
 				</dict>
 			</dict>
 		</array>

--- a/KnockKnock/KnockKnock.pkg.recipe
+++ b/KnockKnock/KnockKnock.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/KnockKnock.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KnockKnock.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/KnockKnock.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/MachOView/MachOView.pkg.recipe
+++ b/MachOView/MachOView.pkg.recipe
@@ -38,9 +38,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/MachOView.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/MachOView.app</string>
 				<key>overwrite</key>
 				<true/>
 			</dict>

--- a/Micro.blog/Microblog.download.recipe
+++ b/Micro.blog/Microblog.download.recipe
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Micro.blog.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "blog.micro.mac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "3F9MDJ6K4E")</string>
 			</dict>

--- a/Micro.blog/Microblog.install.recipe
+++ b/Micro.blog/Microblog.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Micro.blog.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Micro.blog.app</string>
 				<key>overwrite</key>
 				<string>true</string>
 			</dict>

--- a/Micro.blog/Microblog.munki.recipe
+++ b/Micro.blog/Microblog.munki.recipe
@@ -43,7 +43,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Micro.blog.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Mounty/Mounty.download.recipe
+++ b/Mounty/Mounty.download.recipe
@@ -35,7 +35,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Mounty.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.cu4uc.mounty" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SG6DU88C24)</string>
 			</dict>

--- a/RawTherapee/RawTherapee.pkg.recipe
+++ b/RawTherapee/RawTherapee.pkg.recipe
@@ -38,7 +38,7 @@
 			<key>source_path</key>
 			<string>%RECIPE_CACHE_DIR%/%NAME%/*.app</string>
 			<key>destination_path</key>
-			<string>%pkgroot%/Applications/%NAME%.app</string>
+			<string>%pkgroot%/Applications/RawTherapee.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/RawTherapee.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/Sloth/Sloth.download.recipe
+++ b/Sloth/Sloth.download.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sloth.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "org.sveinbjorn.Sloth" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5WX26Y89JP")</string>
 			</dict>

--- a/Sloth/Sloth.munki.recipe
+++ b/Sloth/Sloth.munki.recipe
@@ -45,7 +45,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Sloth.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Texts/Texts.download.recipe
+++ b/Texts/Texts.download.recipe
@@ -42,7 +42,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texts.app</string>
 				<key>requirements</key>
 				<string>identifier "io.texts.Texts" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "79TQE2Q7PH"</string>
 			</dict>

--- a/Texts/Texts.pkg.recipe
+++ b/Texts/Texts.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Texts.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Texts.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Texts.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleVersion</key>

--- a/Winds/Winds.download.recipe
+++ b/Winds/Winds.download.recipe
@@ -44,7 +44,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Winds.app</string>
 				<key>requirement</key>
                 <string>identifier "io.getstream.winds" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = EHV7XZLAHA</string>
 			</dict>

--- a/bitbar/bitbar.munki.recipe
+++ b/bitbar/bitbar.munki.recipe
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/BitBar.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
 			</dict>

--- a/bitbar/bitbar.pkg.recipe
+++ b/bitbar/bitbar.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/BitBar.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/bleep/bleep.download.recipe
+++ b/bleep/bleep.download.recipe
@@ -40,7 +40,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Bleep.app</string>
 				<key>requirements</key>
 				<string>identifier "com.bittorrent.bleep.osx" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SNBT6M4A7T</string>
 			</dict>

--- a/bleep/bleep.install.recipe
+++ b/bleep/bleep.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 				<dict>
 					<key>source_item</key>
-					<string>%NAME%.app</string>
+					<string>Bleep.app</string>
 					<key>destination_path</key>
 					<string>/Applications/</string>
 				</dict>

--- a/bleep/bleep.pkg.recipe
+++ b/bleep/bleep.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/Bleep.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Bleep.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Bleep.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/cog/cog.munki.recipe
+++ b/cog/cog.munki.recipe
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Cog.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
 			</dict>

--- a/cog/cog.pkg.recipe
+++ b/cog/cog.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Cog.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/create-recovery-partition-installer/create-recovery-partition-installer.install.recipe
+++ b/create-recovery-partition-installer/create-recovery-partition-installer.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 					<dict>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Create Recovery Partition Installer.app</string>
 						<key>destination_path</key>
 						<string>/Applications/</string>
 					</dict>

--- a/create-recovery-partition-installer/create-recovery-partition-installer.pkg.recipe
+++ b/create-recovery-partition-installer/create-recovery-partition-installer.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Create Recovery Partition Installer.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Create Recovery Partition Installer.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Create Recovery Partition Installer.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleVersion</key>

--- a/curb/curb.download.recipe
+++ b/curb/curb.download.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Curb.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "com.mrrsoftware.Curb" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9F4M7VMTU5")</string>
 			</dict>

--- a/curb/curb.install.recipe
+++ b/curb/curb.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>/Applications/%NAME%.app</string>
+                <string>/Applications/Curb.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Curb.app</string>
             </dict>
         </dict>
         <dict>

--- a/curb/curb.munki.recipe
+++ b/curb/curb.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Curb.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
 			</dict>

--- a/curb/curb.pkg.recipe
+++ b/curb/curb.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Curb.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/dash/dash.download.recipe
+++ b/dash/dash.download.recipe
@@ -48,7 +48,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Dash.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "com.kapeli.dashdoc" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S6W832GPM5)</string>
 			</dict>

--- a/dash/dash.install.recipe
+++ b/dash/dash.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>/Applications/%NAME%.app</string>
+                <string>/Applications/Dash.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Dash.app</string>
             </dict>
         </dict>
         <dict>

--- a/dash/dash.munki.recipe
+++ b/dash/dash.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Dash.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
 			</dict>

--- a/dash/dash.pkg.recipe
+++ b/dash/dash.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/dash.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/dictater/dictater.download.recipe
+++ b/dictater/dictater.download.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Dictater.app</string>
 				<key>requirements</key>
 				<string>cdhash H"4a6e2cbe27e093cc420291880380578949cd4fda"</string>
 			</dict>

--- a/dictater/dictater.install.recipe
+++ b/dictater/dictater.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>/Applications/%NAME%.app</string>
+                <string>/Applications/Dictater.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/%NAME%/Dictater.app</string>
             </dict>
         </dict>
         <dict>

--- a/dictater/dictater.munki.recipe
+++ b/dictater/dictater.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Dictater.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg</string>
 			</dict>

--- a/dictater/dictater.pkg.recipe
+++ b/dictater/dictater.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Dictater.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/disk-sensei/disk-sensei.download.recipe
+++ b/disk-sensei/disk-sensei.download.recipe
@@ -33,7 +33,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Disk Sensei.app</string>
 				<key>requirements</key>
 				<string>identifier "net.hockeyapp.sdk.mac" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KYJ84ZC369</string>
 			</dict>

--- a/disk-sensei/disk-sensei.install.recipe
+++ b/disk-sensei/disk-sensei.install.recipe
@@ -22,9 +22,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>/Applications/%NAME%.app</string>
+                <string>/Applications/Disk Sensei.app</string>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Disk Sensei.app</string>
 			</dict>
         </dict>
         <dict>

--- a/disk-sensei/disk-sensei.pkg.recipe
+++ b/disk-sensei/disk-sensei.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Disk Sensei.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Disk Sensei.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Disk Sensei.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -51,7 +51,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Final Cut Library Manager.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "com.arcticwhiteness.finalcutlibrarymanager" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MXZ782EHFK)</string>
 			</dict>

--- a/final-cut-library-manager/final-cut-library-manager.install.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.install.recipe
@@ -22,9 +22,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Final Cut Library Manager.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Final Cut Library Manager.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/final-cut-library-manager/final-cut-library-manager.munki.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Final Cut Library Manager.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>

--- a/final-cut-library-manager/final-cut-library-manager.pkg.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Final Cut Library Manager.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Final Cut Library Manager.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Final Cut Library Manager.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/ghostlab/ghostlab.download.recipe
+++ b/ghostlab/ghostlab.download.recipe
@@ -53,7 +53,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Ghostlab2.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.vanamco.Ghostlab2.www" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = LXJYPFT25V)</string>
 			</dict>

--- a/ghostlab/ghostlab.install.recipe
+++ b/ghostlab/ghostlab.install.recipe
@@ -22,9 +22,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Ghostlab2.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Ghostlab2.app</string>
 			</dict>
 		</dict>
 	</array>

--- a/ghostlab/ghostlab.munki.recipe
+++ b/ghostlab/ghostlab.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Ghostlab2.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>

--- a/ghostlab/ghostlab.pkg.recipe
+++ b/ghostlab/ghostlab.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Ghostlab2.app</string>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%-%version%/Ghostlab2.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Ghostlab2.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/kismac2/kismac2.download.recipe
+++ b/kismac2/kismac2.download.recipe
@@ -37,7 +37,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/KisMac2.app</string>
 				<key>requirement</key>
 				<string>identifier "com.igrsoft.kismac" and anchor apple generic and certificate leaf[subject.CN] = "Mac Developer: Vitalii Parovishnyk (6RW5R6WG96)" and certificate 1[field.1.2.840.113635.100.6.2.1] /* exists */</string>
 			</dict>

--- a/kismac2/kismac2.install.recipe
+++ b/kismac2/kismac2.install.recipe
@@ -22,9 +22,9 @@
       <key>Arguments</key>
       <dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.dmg/KisMac2.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/KisMac2.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/kismac2/kismac2.pkg.recipe
+++ b/kismac2/kismac2.pkg.recipe
@@ -45,9 +45,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg/KisMac2.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/KisMac2.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -56,7 +56,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/KisMac2.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/mac-linux-usb-loader/mac-linux-usb-loader.download.recipe
+++ b/mac-linux-usb-loader/mac-linux-usb-loader.download.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Mac Linux USB Loader.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "com.sevenbits.Mac-Linux-USB-Loader" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T47PR9EQY5)</string>
 			</dict>

--- a/mac-linux-usb-loader/mac-linux-usb-loader.install.recipe
+++ b/mac-linux-usb-loader/mac-linux-usb-loader.install.recipe
@@ -22,9 +22,9 @@
       <key>Arguments</key>
       <dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Mac Linux USB Loader.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/Mac Linux USB Loader.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/mac-linux-usb-loader/mac-linux-usb-loader.pkg.recipe
+++ b/mac-linux-usb-loader/mac-linux-usb-loader.pkg.recipe
@@ -45,9 +45,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Mac Linux USB Loader.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Mac Linux USB Loader.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -56,7 +56,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Mac Linux USB Loader.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/paintbrush/paintbrush.install.recipe
+++ b/paintbrush/paintbrush.install.recipe
@@ -31,9 +31,9 @@
             <key>Arguments</key>
             <dict>
                 <key>destination_path</key>
-                <string>/Applications/%NAME%.app</string>
+                <string>/Applications/Paintbrush.app</string>
                 <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/Paintbrush.app</string>
             </dict>
         </dict>
         <dict>

--- a/paintbrush/paintbrush.munki.recipe
+++ b/paintbrush/paintbrush.munki.recipe
@@ -52,7 +52,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Paintbrush.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
 			</dict>

--- a/paintbrush/paintbrush.pkg.recipe
+++ b/paintbrush/paintbrush.pkg.recipe
@@ -45,7 +45,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Paintbrush.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/panoply/panoply.pkg.recipe
+++ b/panoply/panoply.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Panoply.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Panoply.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -47,7 +47,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Panoply.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/past/past.install.recipe
+++ b/past/past.install.recipe
@@ -27,7 +27,7 @@
                 <array>
                     <dict>
                         <key>source_item</key>
-                        <string>%NAME%.app</string>
+                        <string>Past3.app</string>
                         <key>destination_path</key>
                         <string>/Applications/</string>
                     </dict>

--- a/past/past.pkg.recipe
+++ b/past/past.pkg.recipe
@@ -36,9 +36,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Past3.app</string>
 				<key>source_path</key>
-				<string>%pathname%/%NAME%.app</string>
+				<string>%pathname%/Past3.app</string>
 				<key>overwrite</key>
 				<true/>
 			</dict>
@@ -49,7 +49,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Past3.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/pdfsam/pdfsam.install.recipe
+++ b/pdfsam/pdfsam.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 					<dict>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>PDFsam.app</string>
 						<key>destination_path</key>
 						<string>/Applications/</string>
 					</dict>

--- a/typora/typora.install.recipe
+++ b/typora/typora.install.recipe
@@ -29,7 +29,7 @@
 						<key>destination_path</key>
 						<string>/Applications</string>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>Typora.app</string>
 						<key>user</key>
 						<string>root</string>
 						<key>group</key>

--- a/typora/typora.pkg.recipe
+++ b/typora/typora.pkg.recipe
@@ -45,9 +45,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Typora.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/Typora.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -56,7 +56,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/Typora.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>

--- a/upterm/upterm.install.recipe
+++ b/upterm/upterm.install.recipe
@@ -27,7 +27,7 @@
 				<array>
 					<dict>
 						<key>source_item</key>
-						<string>%NAME%.app</string>
+						<string>upterm.app</string>
 						<key>destination_path</key>
 						<string>/Applications/</string>
 					</dict>

--- a/xact/xact.download.recipe
+++ b/xact/xact.download.recipe
@@ -46,7 +46,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/xACT.app</string>
 				<key>requirements</key>
 				<string>anchor apple generic and identifier "org.scottcbrown.xact" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4N58L7SP37")</string>
 			</dict>

--- a/xact/xact.install.recipe
+++ b/xact/xact.install.recipe
@@ -22,9 +22,9 @@
       <key>Arguments</key>
       <dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/xACT.app</string>
 				<key>destination_path</key>
-				<string>/Applications/%NAME%.app</string>
+				<string>/Applications/xACT.app</string>
 			</dict>
 		</dict>
 		<dict>

--- a/xact/xact.munki.recipe
+++ b/xact/xact.munki.recipe
@@ -43,7 +43,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/xACT.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>

--- a/xact/xact.pkg.recipe
+++ b/xact/xact.pkg.recipe
@@ -45,9 +45,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>source_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/xACT.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app</string>
+				<string>%pkgroot%/Applications/xACT.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -56,7 +56,7 @@
 		<key>Arguments</key>
 			<dict>
 				<key>info_path</key>
-				<string>%pkgroot%/Applications/%NAME%.app/Contents/Info.plist</string>
+				<string>%pkgroot%/Applications/xACT.app/Contents/Info.plist</string>
 				<key>plist_keys</key>
 				<dict>
 					<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.