### PR TITLE
Switch from CURL* back to URL* processors

### DIFF
--- a/Hyper/Hyper.download.recipe
+++ b/Hyper/Hyper.download.recipe
@@ -16,7 +16,7 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>

--- a/disk-sensei/disk-sensei.download.recipe
+++ b/disk-sensei/disk-sensei.download.recipe
@@ -16,7 +16,7 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>CURLDownloader</string>
+			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>


### PR DESCRIPTION
As of [AutoPkg 0.6.0](https://github.com/autopkg/autopkg/tree/v0.6.0), it's safe to switch back to the "standard" URLDownloader and URLTextSearcher processors.