### PR TITLE
Change SuspiciousPackageApp.install to skip packaging

### DIFF
--- a/SuspiciousPackageApp/SuspiciousPackageApp.install.recipe
+++ b/SuspiciousPackageApp/SuspiciousPackageApp.install.recipe
@@ -10,22 +10,31 @@
 	<dict>
 		<key>NAME</key>
 		<string>SuspiciousPackageApp</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.9</string>
-    <key>ParentRecipe</key>
-    <string>com.github.poundbangbash.eholtam-recipes.pkg.SuspiciousPackageApp</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>Installer</string>
-            <key>Arguments</key>
-            <dict>
-                <key>pkg_path</key>
-                <string>%pkg_path%</string>
-        	</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+	<key>ParentRecipe</key>
+	<string>com.github.poundbangbash.eholtam-recipes.pkg.SuspiciousPackageApp</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>InstallFromDMG</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%pathname%</string>
+				<key>items_to_copy</key>
+				<array>
+					<dict>
+						<key>destination_path</key>
+						<string>/Applications/</string>
+						<key>source_item</key>
+						<string>Suspicious Package.app</string>
+					</dict>
+				</array>
+			</dict>
 		</dict>
-   	</array>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Eliminates packaging step and directly installs the App using InstallFromDMG. Formatting also cleaned up.