### PR TITLE
update regex for newest version of Jabref

### DIFF
--- a/JabRef/JabRef.download.recipe
+++ b/JabRef/JabRef.download.recipe
@@ -23,7 +23,7 @@
 				<key>github_repo</key>
 				<string>JabRef/jabref</string>
 				<key>asset_regex</key>
-				<string>JabRef_mac[\S]+\.dmg</string>
+				<string>JabRef-[\S]+\.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
@andrewvalentine Jabref changed the filenames in their releases. I adjusted the regex so that the newest version of Jabref will be downloaded from https://github.com/JabRef/jabref/releases