### PR TITLE
Fix paintbrush.download recipe

### DIFF
--- a/paintbrush/paintbrush.download.recipe
+++ b/paintbrush/paintbrush.download.recipe
@@ -15,22 +15,24 @@
 	<string>0.2.9</string>
 	<key>Process</key>
 	<array>
-		<dict>
-			<key>Processor</key>
-			<string>SparkleUpdateInfoProvider</string>
-			<key>Arguments</key>
-			<dict>
-				<key>appcast_url</key>
-				<string>http://paintbrush.sourceforge.io/updates2x.xml</string>
-			</dict>
-		</dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>SOURCEFORGE_FILE_PATTERN</key>
+                <string>(?P&lt;url2&gt;[\.0-9]*)/.*\.zip</string>
+                <key>SOURCEFORGE_PROJECT_NAME</key>
+                <string>paintbrush</string>
+            </dict>
+            <key>Processor</key>
+            <string>com.github.jessepeterson.munki.GrandPerspective/SourceForgeURLProvider</string>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%url%</string>
+				<key>filename</key>
+				<string>%NAME%.zip</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Download URL from Sparkle feed was failing with a 503 error. Switched to using SourceForgeURLProvider to get a more direct URL from Sourceforge.