### PR TITLE
change regex for Veracrypt URL

### DIFF
--- a/VeraCrypt/VeraCrypt.download.recipe
+++ b/VeraCrypt/VeraCrypt.download.recipe
@@ -19,7 +19,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>https:\/\/launchpad\.net\/veracrypt\/trunk\/.*\..*\/\+download\/VeraCrypt_(?P&lt;downloadversion&gt;\d*\.\d*)\.dmg</string>
+				<string>https:\/\/launchpad\.net\/veracrypt\/trunk\/\d.\d{2}.{0,10}\/\+download\/VeraCrypt_\d.\d{2}.{0,10}\.dmg</string>
 				<key>url</key>
 				<string>https://launchpad.net/veracrypt</string>
 			</dict>
@@ -32,7 +32,7 @@
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 				<key>url</key>
-				<string>https://launchpad.net/veracrypt/trunk/%downloadversion%/+download/VeraCrypt_%downloadversion%.dmg</string>
+				<string>%match%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Hey @andrewvalentine 
I updated the Regex for the VeraCrypt Recipe. 
They have some weird uppercase in the link so I had to match the whole link instead of the the version name only. 
Best Regards and Happy holidays
Tim