### PR TITLE
Adjust name of CodeSignatureVerifier argument

### DIFF
--- a/DetectX/DetectX.munki.recipe
+++ b/DetectX/DetectX.munki.recipe
@@ -38,21 +38,6 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>CodeSignatureVerifier</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX.app</string>
-				<key>requirement</key>
-				<string>anchor apple generic and identifier "com.sqwarq.DetectX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MAJ5XBJSG3)</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>DmgCreator</string>
 			<key>Arguments</key>
 			<dict>

--- a/DetectX/DetectX.munki.recipe
+++ b/DetectX/DetectX.munki.recipe
@@ -47,7 +47,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/DetectX.app</string>
-				<key>requires</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.sqwarq.DetectX" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MAJ5XBJSG3)</string>
 			</dict>
 		</dict>

--- a/Gitter/Gitter.download.recipe
+++ b/Gitter/Gitter.download.recipe
@@ -42,7 +42,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Gitter.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.troupe.gitter.mac.Gitter" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = A86QBWJ43W)</string>
 			</dict>
 		</dict>

--- a/Texts/Texts.download.recipe
+++ b/Texts/Texts.download.recipe
@@ -44,7 +44,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Texts.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "io.texts.Texts" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "79TQE2Q7PH"</string>
 			</dict>
 		</dict>

--- a/bleep/bleep.download.recipe
+++ b/bleep/bleep.download.recipe
@@ -42,7 +42,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Bleep.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "com.bittorrent.bleep.osx" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = SNBT6M4A7T</string>
 			</dict>
 		</dict>

--- a/curb/curb.download.recipe
+++ b/curb/curb.download.recipe
@@ -50,7 +50,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Curb.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mrrsoftware.Curb" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9F4M7VMTU5")</string>
 			</dict>
 		</dict>

--- a/dash/dash.download.recipe
+++ b/dash/dash.download.recipe
@@ -50,7 +50,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Dash.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.kapeli.dashdoc" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = S6W832GPM5)</string>
 			</dict>
 		</dict>

--- a/dictater/dictater.download.recipe
+++ b/dictater/dictater.download.recipe
@@ -48,7 +48,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Dictater.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>cdhash H"4a6e2cbe27e093cc420291880380578949cd4fda"</string>
 			</dict>
 		</dict>

--- a/disk-sensei/disk-sensei.download.recipe
+++ b/disk-sensei/disk-sensei.download.recipe
@@ -36,7 +36,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Disk Sensei.app</string>
 				<key>requirement</key>
-				<string>identifier "net.hockeyapp.sdk.mac" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KYJ84ZC369</string>
+				<string>anchor apple generic and identifier "org.cindori.Disk-Sensei" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = ZQK6SX26CE)</string>
 			</dict>
 		</dict>
 		<dict>

--- a/disk-sensei/disk-sensei.download.recipe
+++ b/disk-sensei/disk-sensei.download.recipe
@@ -35,7 +35,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Disk Sensei.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "net.hockeyapp.sdk.mac" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KYJ84ZC369</string>
 			</dict>
 		</dict>

--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -53,7 +53,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/Final Cut Library Manager.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.arcticwhiteness.finalcutlibrarymanager" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = MXZ782EHFK)</string>
 			</dict>
 		</dict>

--- a/iShowUInstant/iShowUInstant.download.recipe
+++ b/iShowUInstant/iShowUInstant.download.recipe
@@ -42,7 +42,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/%APPNAME%.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "com.shinywhitebox.iShowU-Instant" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PMJ275ZTUX</string>
 			</dict>
 		</dict>

--- a/mac-linux-usb-loader/mac-linux-usb-loader.download.recipe
+++ b/mac-linux-usb-loader/mac-linux-usb-loader.download.recipe
@@ -48,7 +48,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/Mac Linux USB Loader.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.sevenbits.Mac-Linux-USB-Loader" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = T47PR9EQY5)</string>
 			</dict>
 		</dict>

--- a/pdfsam/pdfsam.download.recipe
+++ b/pdfsam/pdfsam.download.recipe
@@ -46,7 +46,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>identifier "pdfsam-4" and certificate leaf = H"6736a6beac8ac9daef8873701959009b4a70c251"</string>
 			</dict>
 		</dict>

--- a/typora/typora.download.recipe
+++ b/typora/typora.download.recipe
@@ -37,7 +37,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "abnerworks.Typora" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9HWK5273G4")</string>
 			</dict>
 		</dict>

--- a/xact/xact.download.recipe
+++ b/xact/xact.download.recipe
@@ -48,7 +48,7 @@
 			<dict>
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/xACT.app</string>
-				<key>requirements</key>
+				<key>requirement</key>
 				<string>anchor apple generic and identifier "org.scottcbrown.xact" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "4N58L7SP37")</string>
 			</dict>
 		</dict>


### PR DESCRIPTION
The correct argument name for [CodeSignatureVerifier](https://github.com/autopkg/autopkg/wiki/Processor-CodeSignatureVerifier) is `requirement`.