### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/VeraCrypt/VeraCrypt.pkg.recipe
+++ b/VeraCrypt/VeraCrypt.pkg.recipe
@@ -8,8 +8,6 @@
 	<string>com.github.andrewvalentine.pkg.VeraCrypt</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>org.idrix.VeraCrypt</string>
 		<key>NAME</key>
 		<string>VeraCrypt</string>
 	</dict>
@@ -20,26 +18,26 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>FlatPkgUnpacker</string>
 			<key>Arguments</key>
 			<dict>
-				<key>flat_pkg_path</key>
-				<string>%pathname%/*.pkg</string>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/pkg/</string>
+				<key>flat_pkg_path</key>
+				<string>%pathname%/*.pkg</string>
 			</dict>
+			<key>Processor</key>
+			<string>FlatPkgUnpacker</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>FlatPkgPacker</string>
 			<key>Arguments</key>
 			<dict>
-				<key>source_flatpkg_dir</key>
-				<string>%RECIPE_CACHE_DIR%/pkg/%NAME%.pkg</string>
 				<key>destination_pkg</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%-%version%.pkg</string>
+				<key>source_flatpkg_dir</key>
+				<string>%RECIPE_CACHE_DIR%/pkg/%NAME%.pkg</string>
 			</dict>
+			<key>Processor</key>
+			<string>FlatPkgPacker</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ❌ VeraCrypt/VeraCrypt.pkg.recipe

```
% /usr/local/bin/autopkg run -vvcq repos/andrewvalentine-recipes/VeraCrypt/VeraCrypt.pkg.recipe
Processing repos/andrewvalentine-recipes/VeraCrypt/VeraCrypt.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'https:\\/\\/launchpad\\.net\\/veracrypt\\/trunk\\/.*\\..*\\/\\+download\\/VeraCrypt_(?P<downloadversion>\\d*\\.\\d*)\\.dmg',
           'url': 'https://launchpad.net/veracrypt'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
Receipt written to ~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.VeraCrypt/receipts/VeraCrypt.pkg-receipt-20210213-205753.plist

The following recipes failed:
    repos/andrewvalentine-recipes/VeraCrypt/VeraCrypt.pkg.recipe
        Error in com.github.andrewvalentine.pkg.VeraCrypt: Processor: URLTextSearcher: Error: No match found on URL: https://launchpad.net/veracrypt

Nothing downloaded, packaged or imported.
```

