### PR TITLE
Update JD-GUI.munki.recipe

### DIFF
--- a/JavaDecompiler-GUI/JD-GUI.munki.recipe
+++ b/JavaDecompiler-GUI/JD-GUI.munki.recipe
@@ -28,6 +28,23 @@
 			<string>%NAME%</string>
 			<key>name</key>
 			<string>%NAME%</string>
+            <key>postinstall_script</key>
+            <string>#!/bin/bash
+#
+# Copyright (c) 2021, dataJAR Ltd.  All rights reserved.
+#
+
+# Info.plist needs amending as per: https://github.com/java-decompiler/jd-gui/issues/346#issuecomment-795047028
+
+if [ -f "/Applications/JD-GUI.app/Contents/Info.plist" ]
+then
+    /bin/echo "Found/Applications/JD-GUI.app/Contents/Info.plist, amending info.plist..."
+    /usr/libexec/PlistBuddy -c "set :JavaX:JVMVersion 1.8.0" /Applications/JD-GUI.app/Contents/Info.plist
+fi</string>
+            <key>requires</key>
+			<array>
+				<string>OracleJava8JDK</string>
+			</array>
 			<key>unattended_install</key>
 			<true/>
 		</dict>
@@ -38,19 +55,68 @@
 	<string>com.github.andrewvalentine.download.jdgui</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>Unarchiver</string>
+            <key>Arguments</key>
+            <dict>
+                <key>archive_path</key>
+                <string>%pathname%</string>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/untar/</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>Copier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/JD-GUI.app</string>
+                <key>source_path</key>
+                <string>%RECIPE_CACHE_DIR%/untar/*/JD-GUI.app</string>
+                <key>overwrite</key>
+                <true/>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>DmgCreator</string>
+            <key>Arguments</key>
+            <dict>
+                <key>dmg_path</key>
+                <string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
+                <key>dmg_root</key>
+                <string>%RECIPE_CACHE_DIR%/Applications/</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%pathname%</string>
+				<string>%dmg_path%</string>
 				<key>MUNKI_REPO</key>
 				<string>%MUNKI_REPO%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>
 		</dict>
+        <dict>
+            <key>Processor</key>
+            <string>PathDeleter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>path_list</key>
+                <array>
+                    <string>%RECIPE_CACHE_DIR%/Applications</string>
+                    <string>%RECIPE_CACHE_DIR%/untar</string>
+                </array>
+            </dict>
+        </dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Recipe was failing as was being passed the .tar, amended to expand the .tar and create a DMG for importing.

Also, the app would not then launch as needs OracleJava8JDK and the info.plist amending as per: https://github.com/java-decompiler/jd-gui/issues/346#issuecomment-795047028