### PR TITLE
KnockKnock: download URL changed to github repo

### DIFF
--- a/KnockKnock/KnockKnock.download.recipe
+++ b/KnockKnock/KnockKnock.download.recipe
@@ -16,24 +16,22 @@
 	<key>Process</key>
 	<array>
 		<dict>
-			<key>Processor</key>
-			<string>URLTextSearcher</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://bitbucket.org/objective-see/deploy/downloads</string>
-				<key>re_pattern</key>
-				<string>%NAME%_[0-9\.]*.zip</string>
+				<key>github_repo</key>
+				<string>objective-see/KnockKnock</string>
 			</dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
-			<key>Processor</key>
-			<string>URLDownloader</string>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%url%/%match%</string>
+				<key>filename</key>
+				<string>%NAME%.zip</string>
 			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
 		</dict>
 		<dict>
 			<key>Processor</key>


### PR DESCRIPTION
The bitbucket URL currently offers v2.1.1, which is outdated. Moreover, downloading directly from the project's repository reduces complexity.