### PR TITLE
update cert trust chain for mullvad

### DIFF
--- a/Mullvad/Mullvad.download.recipe
+++ b/Mullvad/Mullvad.download.recipe
@@ -48,7 +48,7 @@
 				<string>%pathname%</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: Amagicom AB (G7CDBEG477)</string>
+					<string>Developer ID Installer: Mullvad VPN AB (CKG9MXH72F)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
it looks like the certificate that mullvad uses to sign their package has updated. this change makes this change to the package i downloaded today (MullvadVPN-2023.4.pkg)