### PR TITLE
KnockKnock: pkginfo issues

### DIFF
--- a/KnockKnock/KnockKnock.munki.recipe
+++ b/KnockKnock/KnockKnock.munki.recipe
@@ -8,20 +8,30 @@
 	<string>com.github.andrewvalentine.munki.KnockKnock</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>KnockKnock</string>
 		<key>MUNKI_REPO_SUBDIR</key>
 		<string>apps/KnockKnock</string>
+		<key>NAME</key>
+		<string>KnockKnock</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
 			<array>
 				<string>testing</string>
 			</array>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>description</key>
+			<string>Malware installs itself persistently, to ensure it is automatically executed each time a computer is restarted. KnockKnock uncovers persistently installed software in order to generically reveal such malware.</string>
+			<key>developer</key>
+			<string>Objective-See</string>
 			<key>display_name</key>
 			<string>%NAME%</string>
 			<key>name</key>
 			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+			<key>unattended_uninstall</key>
+			<true/>
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
@@ -32,6 +42,18 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>minimum_os_version</key>
+					<string>%minimum_os_version%</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
@@ -39,15 +61,6 @@
 				<string>%RECIPE_CACHE_DIR%/%NAME%.pkg</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
-				<key>pkginfo</key>
-				<dict>
-					<key>category</key>
-					<string>Utilities</string>
-					<key>description</key>
-					<string>Malware installs itself persistently, to ensure it is automatically executed each time a computer is restarted. KnockKnock uncovers persistently installed software in order to generically reveal such malware.</string>
-					<key>developer</key>
-					<string>Objective-See</string>
-				</dict>
 			</dict>
 		</dict>
 	</array>

--- a/KnockKnock/KnockKnock.pkg.recipe
+++ b/KnockKnock/KnockKnock.pkg.recipe
@@ -55,6 +55,8 @@
 					<string>version</string>
 					<key>CFBundleIdentifier</key>
 					<string>identifier</string>
+					<key>LSMinimumSystemVersion</key>
+					<string>minimum_os_version</string>
 				</dict>
 			</dict>
 		</dict>


### PR DESCRIPTION
- Extract LSMinimumVersion in pkg recipe to be used in pkginfo section of munki recipe (defaulted to 10.5 before)
- Moved pkginfo keys into pkginfo section in munki recipe (allows adoption in overrides)
- Added unattended_install and unattended_uninstall keys set to true