### PR TITLE
update search and download URLs and RE pattern

### DIFF
--- a/MestReNova/MestReNova.download.recipe
+++ b/MestReNova/MestReNova.download.recipe
@@ -9,9 +9,9 @@
 	<key>Input</key>
 	<dict>
 		<key>SEARCH_URL</key>
-		<string>https://mestrelab.com/download/mnova/</string>
+		<string>https://mestrelab.com/download/</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://mestrelab.com/downloads/mnova/mac</string>
+		<string>https://mestrelab.com/downloads/mnova</string>
 		<key>NAME</key>
 		<string>MestReNova</string>
 	</dict>
@@ -25,7 +25,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>re_pattern</key>
-				<string>%NAME%-.*-.*.dmg</string>
+				<string>mac/%NAME%-.*-.*.dmg</string>
 				<key>url</key>
 				<string>%SEARCH_URL%</string>
 			</dict>


### PR DESCRIPTION
Mestrelab made changes to their download page that broke the MestReNova.download recipe.  This pull request adjusts the recipe to work with the new page.

Verbose autopkg output attached 

[output.txt](https://github.com/user-attachments/files/17115367/output.txt)


