### PR TITLE
Deprecate Final Cut Library Manager recipes

### DIFF
--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -17,6 +17,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the FinalCutLibraryManager recipes in the macvfx-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>

--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -12,7 +12,7 @@
 		<string>Final Cut Library Manager</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/final-cut-library-manager/final-cut-library-manager.install.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.install.recipe
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>ParentRecipe</key>
-    <string>com.github.andrewvalentine.download.final-cut-library-manager</string>
+    <string>com.github.autopkg.macvfx.download.FinalCutLibraryManager</string>
     <key>Process</key>
     <array>
 		<dict>

--- a/final-cut-library-manager/final-cut-library-manager.munki.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.munki.recipe
@@ -33,7 +33,7 @@
 		</dict>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>ParentRecipe</key>
 	<string>com.github.andrewvalentine.download.final-cut-library-manager</string>
 	<key>Process</key>

--- a/final-cut-library-manager/final-cut-library-manager.munki.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.munki.recipe
@@ -40,6 +40,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the FinalCutLibraryManager recipes in the macvfx-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>DmgCreator</string>
 			<key>Arguments</key>
 			<dict>

--- a/final-cut-library-manager/final-cut-library-manager.pkg.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
 	<key>ParentRecipe</key>
-	<string>com.github.andrewvalentine.download.final-cut-library-manager</string>
+	<string>com.github.autopkg.macvfx.download.FinalCutLibraryManager</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The Final Cut Library Manager recipes are redundant with those in the macvfx-recipes repo. This PR marks the download and munki recipes as deprecated and points the install and pkg recipes to macvfx-recipes parent recipes.