### PR TITLE
Deprecate Final Cut Library Manager recipes

### DIFF
--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -12,7 +12,7 @@
 		<string>Final Cut Library Manager</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/final-cut-library-manager/final-cut-library-manager.download.recipe
+++ b/final-cut-library-manager/final-cut-library-manager.download.recipe
@@ -17,6 +17,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Final Cut Library Manager is now called Arctic. Consider switching to the Arctic recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Final Cut Library Manager is now called Arctic ([details](https://www.arcticwhiteness.com/finalcutlibrarymanager/)), and the previous Sparkle feed has been broken with the latest entry. This PR deprecates the Final Cut Library Manager recipes.