### PR TITLE
Fix BasicTeX download URL and NAME variable issue

### DIFF
--- a/BasicTeX/BasicTeX.download.recipe
+++ b/BasicTeX/BasicTeX.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>BasicTeX</string>
 		<key>DOWNLOAD_URL</key>
-		<string>http://tug.org/cgi-bin/mactex-download/BasicTeX.pkg</string>
+		<string>https://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>

--- a/BasicTeX/BasicTeX.download.recipe
+++ b/BasicTeX/BasicTeX.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>BasicTeX</string>
 		<key>DOWNLOAD_URL</key>
-		<string>http://tug.org/cgi-bin/mactex-download/%NAME%.pkg</string>
+		<string>http://tug.org/cgi-bin/mactex-download/BasicTeX.pkg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>


### PR DESCRIPTION
This PR fixes a situation in which an admin might override the NAME input variable and unintentionally break the recipe's ability to download the software. Since NAME can be customized, NAME should be avoided whenever it's needed for recipe functionality, as in URLs and file paths.

I've also updated the download URL for BasicTeX.
