### PR TITLE
Deprecate KnockKnock recipes

### DIFF
--- a/KnockKnock/KnockKnock.download.recipe
+++ b/KnockKnock/KnockKnock.download.recipe
@@ -12,9 +12,18 @@
 		<string>KnockKnock</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the KnockKnock recipes in the ahousseini-recipes or dataJAR-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
The KnockKnock recipes in this repository are not sufficiently distinct from other recipes in the AutoPkg org to warrant the extra maintenance they will require. This PR deprecates the KnockKnock recipes in this repo and points users to specific alternatives in other repos.

Closes #59