### PR TITLE
Updated CodeSignatureVerifier and MunkiImporter

### DIFF
--- a/Mathematica/Mathematica.munki.recipe
+++ b/Mathematica/Mathematica.munki.recipe
@@ -5,6 +5,8 @@
 	<key>Description</key>
 	<string>Imports Mathematica into Munki.
 
+Important: The app was formally titled "Mathematica" some recipes/elements might still be named after the old app.
+
 This is designed to be run against a local .dmg. To run this recipe successfully, you must:
 
 - Register for a Wolfram ID.
@@ -50,9 +52,9 @@ A postinstall_script that adds Mathematica to the client application firewall is
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%PKG%/Mathematica.app</string>
+				<string>%PKG%/Wolfram.app</string>
 				<key>requirement</key>
-				<string>identifier "com.wolfram.Mathematica" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D2Y8ST33G6</string>
+				<string>identifier "com.wolfram.WolframApp" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = D2Y8ST33G6</string>
 			</dict>
 		</dict>
 		<dict>
@@ -65,7 +67,7 @@ A postinstall_script that adds Mathematica to the client application firewall is
 			<key>Arguments</key>
 			<dict>
 				<key>munkiimport_appname</key>
-				<string>Mathematica.app</string>
+				<string>Wolfram.app</string>
 				<key>pkg_path</key>
 				<string>%PKG%</string>
 				<key>repo_subdirectory</key>


### PR DESCRIPTION
Due to a recent name change from Mathematica to Wolfram, I updated the CodeSignatureVerifier and MunkiImporter.

Following things changed:

- New description informing about the name change
- Changed the app name in the `input_path` key of the CodeSignatureVerifier
- Changed the `requirements` of the CodeSignatureVerifier
- Changed the app name in the `munkiimport_appname` key of the MunkiImporter

I left Mathematica in the `NAME` key and the description.