### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/Fission/Fission.pkg.recipe
+++ b/Fission/Fission.pkg.recipe
@@ -74,8 +74,6 @@
 					</array>
 					<key>id</key>
 					<string>%id%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgdir</key>
 					<string>%RECIPE_CACHE_DIR%</string>
 					<key>pkgname</key>

--- a/MachOView/MachOView.pkg.recipe
+++ b/MachOView/MachOView.pkg.recipe
@@ -68,8 +68,6 @@
 					<string>%pkgroot%</string>
 					<key>id</key>
 					<string>%PKG_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>chown</key>
 					<array>
 						<dict>

--- a/loopdown/loopdown.pkg.recipe.yaml
+++ b/loopdown/loopdown.pkg.recipe.yaml
@@ -33,7 +33,6 @@ Process:
             user: root
             mode: "755"
         id: "%PKG_ID%"
-        options: purge_ds_store
         pkgdir: "%RECIPE_CACHE_DIR%/pkgroot"
         pkgname: "%NAME%-%version%"
         version: "%version%"


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._