### PR TITLE
Deprecate JabRef recipes

### DIFF
--- a/JabRef/JabRef.download.recipe
+++ b/JabRef/JabRef.download.recipe
@@ -12,9 +12,18 @@
 		<string>JabRef</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the JabRef recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
The download and munki recipes for JabRef in this repo are redundant with the JabRef recipes in dataJAR-recipes, and the dataJAR version contains code signature verification.

This consolidation will help simplify search results and lower maintenance effort.