### PR TITLE
Update Franz recipes to support multiple architectures

### DIFF
--- a/Franz/Franz.download.recipe
+++ b/Franz/Franz.download.recipe
@@ -18,7 +18,7 @@ Set ARCH to blank for Intel, or -arm64 for Apple Silicon.
 		<key>INCLUDE_PRERELEASES</key>
 		<string></string>
 		<key>ARCH</key>
-		<string></string>
+		<string>-arm64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>
@@ -30,7 +30,7 @@ Set ARCH to blank for Intel, or -arm64 for Apple Silicon.
 			<key>Arguments</key>
 			<dict>
 				<key>asset_regex</key>
-				<string>%NAME%-[\S]+\.dmg</string>
+				<string>Franz-[\d\.]+%ARCH%\.dmg</string>
 				<key>github_repo</key>
 				<string>meetfranz/franz</string>
 				<key>include_prereleases</key>

--- a/Franz/Franz.download.recipe
+++ b/Franz/Franz.download.recipe
@@ -3,7 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads Franz from Github. Set INCLUDE_PRERELEASES to a non-empty value to download pre-release software.</string>
+	<string>Downloads Franz from Github.
+	
+Set INCLUDE_PRERELEASES to a non-empty value to download pre-release software.
+
+Set ARCH to blank for Intel, or -arm64 for Apple Silicon.
+</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.download.franz</string>
 	<key>Input</key>
@@ -11,6 +16,8 @@
 		<key>NAME</key>
 		<string>Franz</string>
 		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
+		<key>ARCH</key>
 		<string></string>
 	</dict>
 	<key>MinimumVersion</key>


### PR DESCRIPTION
This PR adds the ability to specify which architecture of Franz to download.

The default behavior for the previous version of the recipe was to download the Apple Silicon version. Not sure whether this was intentional, as the asset regex was simply matching non whitespace. This is a more intentional approach, and preserves the previous default behavior.

Verbose recipe run with default (Apple Silicon) download:

```
% autopkg run -vvq 'andrewvalentine-recipes/Franz/Franz.download.recipe'
Processing andrewvalentine-recipes/Franz/Franz.download.recipe...
WARNING: andrewvalentine-recipes/Franz/Franz.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Franz-[\\d\\.]+-arm64\\.dmg',
           'github_repo': 'meetfranz/franz',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Franz-[\d\.]+-arm64\.dmg' among asset(s): Franz-5.11.0-arm64-mac.zip, Franz-5.11.0-arm64-mac.zip.blockmap, Franz-5.11.0-arm64.dmg, Franz-5.11.0-mac.zip, Franz-5.11.0-mac.zip.blockmap, Franz-5.11.0.AppImage, Franz-5.11.0.dmg, franz-5.11.0.tar.gz, Franz-Setup-5.11.0.exe, Franz-Setup-5.11.0.exe.blockmap, franz_5.11.0_amd64.deb, latest-linux.yml, latest-mac.yml, latest.yml, Screenshot.2025-06-10.at.08.54.04.png
GitHubReleasesInfoProvider: Selected asset 'Franz-5.11.0-arm64.dmg' from release '5.11.0'
{'Output': {'asset_created_at': '2025-04-09T09:53:13Z',
            'asset_url': 'https://api.github.com/repos/meetfranz/franz/releases/assets/244845241',
            'release_notes': '### Features\r\n'
                             '\r\n'
                             '- Update electron to 33.3.0\r\n'
                             '\r\n'
                             '### Bug Fixes\r\n'
                             '\r\n'
                             "- **App:** Don't open multiple windows of the "
                             'same type '
                             '([5e3dbec](https://github.com/meetfranz/franz/commit/5e3dbec7cf36cdb59599aac6aca45d1d3136a32a))\r\n'
                             '- **App:** Fix "save image as" '
                             '([db31dc3](https://github.com/meetfranz/franz/commit/db31dc38d9321d6ba915599d05d750ad1e33b8e1))\r\n'
                             '- **App:** Fix background colors '
                             '([a28c1d9](https://github.com/meetfranz/franz/commit/a28c1d9547ff693245444b5ce67a26286f656c8d))\r\n'
                             '- **App:** Fix crash on logout '
                             '([69ad832](https://github.com/meetfranz/franz/commit/69ad832a39eda5ded884b965928c93cb85b8aebf))\r\n'
                             '- **App:** Fix screen not being shared after '
                             'selecting source '
                             '([313ca03](https://github.com/meetfranz/franz/commit/313ca031915fa6d603f05a4aa88f5124ed237c2d))\r\n'
                             '- **App:** Fix share screen selection styles '
                             '([04a3d43](https://github.com/meetfranz/franz/commit/04a3d43d10c51861292fc51f2de0e176b0656ecc))\r\n'
                             '- **App:** Improve image quality of window '
                             'previews in share screen selection '
                             '([30f445c](https://github.com/meetfranz/franz/commit/30f445c4fa81fe06c28b7ff76a95f847f59ca6c0))\r\n'
                             '- **macOS:** Open System Settings when asking '
                             'for screen share permissions '
                             '([4bf7af8](https://github.com/meetfranz/franz/commit/4bf7af8c3b5745f6c6bc32baf1dde477bbec26d8))\r\n'
                             '- **Screen Share:** Fix missing background color '
                             '([2627430](https://github.com/meetfranz/franz/commit/262743019c82862de00a58dd62155d8c3589a597))\r\n'
                             '- **Service:** Fix custom service icon upload '
                             '([97c34d4](https://github.com/meetfranz/franz/commit/97c34d4da0c322464df588ec1a258b71c66b7245))\r\n'
                             '- **Todos:** Add check if recipes have been '
                             'loaded before downloading todos-recipe '
                             '([76fea86](https://github.com/meetfranz/franz/commit/76fea86a72f5e34455d26687a209a91590e67e68))\r\n'
                             '- **WebView:** Set default background color to '
                             'white '
                             '([7fdf915](https://github.com/meetfranz/franz/commit/7fdf91515e61fa293ebe9df70a39ed29baee158a))',
            'url': 'https://github.com/meetfranz/franz/releases/download/v5.11.0/Franz-5.11.0-arm64.dmg',
            'version': '5.11.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/meetfranz/franz/releases/download/v5.11.0/Franz-5.11.0-arm64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 09 Apr 2025 09:53:17 GMT
URLDownloader: Storing new ETag header: "0x8DD774C5A61FF52"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD774C5A61FF52"',
            'last_modified': 'Wed, 09 Apr 2025 09:53:17 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg/Franz.app',
           'requirement': 'identifier "com.meetfranz.franz" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'TAC9P63ANZ'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.5W2mwx/Franz.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.5W2mwx/Franz.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.5W2mwx/Franz.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/receipts/Franz.download-receipt-20251026-203907.plist

The following new items were downloaded:
    Download Path                                                                                                   
    -------------                                                                                                   
    ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0-arm64.dmg  
```

Verbose recipe run with Intel download:

```
% autopkg run -vvq 'andrewvalentine-recipes/Franz/Franz.download.recipe' -k ARCH=''
Processing andrewvalentine-recipes/Franz/Franz.download.recipe...
WARNING: andrewvalentine-recipes/Franz/Franz.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': 'Franz-[\\d\\.]+\\.dmg',
           'github_repo': 'meetfranz/franz',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex 'Franz-[\d\.]+\.dmg' among asset(s): Franz-5.11.0-arm64-mac.zip, Franz-5.11.0-arm64-mac.zip.blockmap, Franz-5.11.0-arm64.dmg, Franz-5.11.0-mac.zip, Franz-5.11.0-mac.zip.blockmap, Franz-5.11.0.AppImage, Franz-5.11.0.dmg, franz-5.11.0.tar.gz, Franz-Setup-5.11.0.exe, Franz-Setup-5.11.0.exe.blockmap, franz_5.11.0_amd64.deb, latest-linux.yml, latest-mac.yml, latest.yml, Screenshot.2025-06-10.at.08.54.04.png
GitHubReleasesInfoProvider: Selected asset 'Franz-5.11.0.dmg' from release '5.11.0'
{'Output': {'asset_created_at': '2025-04-09T09:51:01Z',
            'asset_url': 'https://api.github.com/repos/meetfranz/franz/releases/assets/244844841',
            'release_notes': '### Features\r\n'
                             '\r\n'
                             '- Update electron to 33.3.0\r\n'
                             '\r\n'
                             '### Bug Fixes\r\n'
                             '\r\n'
                             "- **App:** Don't open multiple windows of the "
                             'same type '
                             '([5e3dbec](https://github.com/meetfranz/franz/commit/5e3dbec7cf36cdb59599aac6aca45d1d3136a32a))\r\n'
                             '- **App:** Fix "save image as" '
                             '([db31dc3](https://github.com/meetfranz/franz/commit/db31dc38d9321d6ba915599d05d750ad1e33b8e1))\r\n'
                             '- **App:** Fix background colors '
                             '([a28c1d9](https://github.com/meetfranz/franz/commit/a28c1d9547ff693245444b5ce67a26286f656c8d))\r\n'
                             '- **App:** Fix crash on logout '
                             '([69ad832](https://github.com/meetfranz/franz/commit/69ad832a39eda5ded884b965928c93cb85b8aebf))\r\n'
                             '- **App:** Fix screen not being shared after '
                             'selecting source '
                             '([313ca03](https://github.com/meetfranz/franz/commit/313ca031915fa6d603f05a4aa88f5124ed237c2d))\r\n'
                             '- **App:** Fix share screen selection styles '
                             '([04a3d43](https://github.com/meetfranz/franz/commit/04a3d43d10c51861292fc51f2de0e176b0656ecc))\r\n'
                             '- **App:** Improve image quality of window '
                             'previews in share screen selection '
                             '([30f445c](https://github.com/meetfranz/franz/commit/30f445c4fa81fe06c28b7ff76a95f847f59ca6c0))\r\n'
                             '- **macOS:** Open System Settings when asking '
                             'for screen share permissions '
                             '([4bf7af8](https://github.com/meetfranz/franz/commit/4bf7af8c3b5745f6c6bc32baf1dde477bbec26d8))\r\n'
                             '- **Screen Share:** Fix missing background color '
                             '([2627430](https://github.com/meetfranz/franz/commit/262743019c82862de00a58dd62155d8c3589a597))\r\n'
                             '- **Service:** Fix custom service icon upload '
                             '([97c34d4](https://github.com/meetfranz/franz/commit/97c34d4da0c322464df588ec1a258b71c66b7245))\r\n'
                             '- **Todos:** Add check if recipes have been '
                             'loaded before downloading todos-recipe '
                             '([76fea86](https://github.com/meetfranz/franz/commit/76fea86a72f5e34455d26687a209a91590e67e68))\r\n'
                             '- **WebView:** Set default background color to '
                             'white '
                             '([7fdf915](https://github.com/meetfranz/franz/commit/7fdf91515e61fa293ebe9df70a39ed29baee158a))',
            'url': 'https://github.com/meetfranz/franz/releases/download/v5.11.0/Franz-5.11.0.dmg',
            'version': '5.11.0'}}
URLDownloader
{'Input': {'url': 'https://github.com/meetfranz/franz/releases/download/v5.11.0/Franz-5.11.0.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Wed, 09 Apr 2025 09:51:07 GMT
URLDownloader: Storing new ETag header: "0x8DD774C0CE1EE8D"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD774C0CE1EE8D"',
            'last_modified': 'Wed, 09 Apr 2025 09:51:07 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg/Franz.app',
           'requirement': 'identifier "com.meetfranz.franz" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'TAC9P63ANZ'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.ezfUMl/Franz.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.ezfUMl/Franz.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.ezfUMl/Franz.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/receipts/Franz.download-receipt-20251026-203943.plist

The following new items were downloaded:
    Download Path                                                                                             
    -------------                                                                                             
    ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.franz/downloads/Franz-5.11.0.dmg
```