### PR TITLE
Change PDFsam parent to ahousseini's download

### DIFF
--- a/pdfsam/pdfsam.download.recipe
+++ b/pdfsam/pdfsam.download.recipe
@@ -12,9 +12,18 @@
 		<string>PDFsam</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the PDFsam recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/pdfsam/pdfsam.install.recipe
+++ b/pdfsam/pdfsam.install.recipe
@@ -14,7 +14,7 @@
     <key>MinimumVersion</key>
     <string>0.2.9</string>
     <key>ParentRecipe</key>
-    <string>com.github.andrewvalentine.download.pdfsam</string>
+    <string>com.github.ahousseini-recipes.download.PDFsamBasic</string>
     <key>Process</key>
     <array>
 		<dict>

--- a/pdfsam/pdfsam.munki.recipe
+++ b/pdfsam/pdfsam.munki.recipe
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
 	<key>ParentRecipe</key>
-	<string>com.github.andrewvalentine.download.pdfsam</string>
+	<string>com.github.ahousseini-recipes.download.PDFsamBasic</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The PDFsam download recipe in this repo is broken, and similar in function the working one in ahousseini-recipes. This PR adjusts the parent download recipe for the munki and install recipe to ahousseini's download recipe, and deprecates the non-working download and pkg recipes in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!