### PR TITLE
Change parent of BasicTeX.munki

### DIFF
--- a/BasicTeX/BasicTeX.download.recipe
+++ b/BasicTeX/BasicTeX.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://mirror.ctan.org/systems/mac/mactex/BasicTeX.pkg</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.6.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the BasicTeX recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>

--- a/BasicTeX/BasicTeX.munki.recipe
+++ b/BasicTeX/BasicTeX.munki.recipe
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.6.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.andrewvalentine.download.basictex</string>
+	<string>com.github.grahampugh.recipes.download.BasicTeX</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
The BasicTeX download recipe in this repo is similar in function the ones in grahampugh-recipes. This PR adjusts the BasicTeX munki recipe to use grahampugh's download recipe as a parent.

This consolidation will help simplify search results and lower maintenance effort. Thank you!