### PR TITLE
Deprecate Dash recipes

### DIFF
--- a/dash/dash.download.recipe
+++ b/dash/dash.download.recipe
@@ -14,9 +14,18 @@
 		<string>https://kapeli.com/Dash3.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Dash recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>


### PR DESCRIPTION
Dash 3 is no longer being updated. The latest version is Dash 8. The hjuutilainen-recipes repo has Dash recipes with a `MAJOR_VERSION` input variable that work with all the recent versions from 4 through 8. This PR deprecates the ones in this repo in favor of those more flexible alternatives.

Thanks for considering!