### PR TITLE
Update Typora download URL and input_path

### DIFF
--- a/typora/typora.download.recipe
+++ b/typora/typora.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Typora</string>
 		<key>URL</key>
-		<string>https://typora.io/download/Typora.dmg</string>
+		<string>https://downloads.typora.io/mac/Typora.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
@@ -36,7 +36,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%pathname%</string>
+				<string>%pathname%/Typora.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "abnerworks.Typora" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "9HWK5273G4")</string>
 			</dict>


### PR DESCRIPTION
Hi, @andrewvalentine 

The current Typora recipes currently fail with 
```
The following recipes failed:
    /Users/ec2-user/Library/AutoPkg/RecipeOverrides/typora.munki.recipe
        Error in local.munki.typora: Processor: URLDownloader: Error: curl: (56) The requested URL returned error: 404
```

And (once the URL has been updated)
```
The following recipes failed:
    /Users/ec2-user/Library/AutoPkg/RecipeOverrides/typora.munki.recipe
        Error in local.munki.typora: Processor: CodeSignatureVerifier: Error: Code signature verification failed. Note that all verifications can be disabled by setting the variable DISABLE_CODE_SIGNATURE_VERIFICATION to a non-empty value.
```

This PR switches the Typora download URL to downloads.typora.io/mac/Typora.dmg and adjusts the installer input_path to "%pathname%/Typora.app" so the signing/requirement check targets the extracted app bundle rather than the archive path.

Output from a successful -v run

```
autopkg run -v typora.munki.recipe 
Processing typora.munki.recipe...
WARNING: typora.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Storing new Last-Modified header: Wed, 31 Dec 2025 03:31:07 GMT
URLDownloader: Storing new ETag header: "97275380cae963f42b5b2cc000659351"
URLDownloader: Downloaded /Users/paul.cossey/Library/AutoPkg/Cache/com.github.andrewvalentine.munki.typora/downloads/Typora.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.andrewvalentine.munki.typora/downloads/Typora.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.lz6oE7/Typora.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.lz6oE7/Typora.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.lz6oE7/Typora.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Typora/Typora-1.12.6.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Typora/Typora-1.12.6.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.andrewvalentine.munki.typora/receipts/typora.munki-receipt-20260311-111713.plist

The following new items were downloaded:
    Download Path                                                                                          
    -------------                                                                                          
    /Users/paul.cossey/Library/AutoPkg/Cache/com.github.andrewvalentine.munki.typora/downloads/Typora.dmg  

The following new items were imported into Munki:
    Name    Version  Catalogs  Pkginfo Path                     Pkg Repo Path                  Icon Repo Path  
    ----    -------  --------  ------------                     -------------                  --------------  
    Typora  1.12.6   testing   apps/Typora/Typora-1.12.6.plist  apps/Typora/Typora-1.12.6.dmg
```