### PR TITLE
Add ARCH input variable to Hyper.download recipe

### DIFF
--- a/Hyper/Hyper.download.recipe
+++ b/Hyper/Hyper.download.recipe
@@ -3,11 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest version of Hyper</string>
+	<string>Downloads the latest version of Hyper.
+
+Use the ARCH input variable to specify the architecture to download.
+Values at the time of writing are:
+
+- dmg (Intel, default)
+- dmg_arm64 (Apple Silicon)
+	</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.download.hyper</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>dmg</string>
 		<key>NAME</key>
 		<string>Hyper</string>
 	</dict>
@@ -21,7 +30,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://releases.hyper.is/download/mac</string>
+				<string>https://releases.hyper.is/download/%ARCH%</string>
 				<key>filename</key>
 				<string>%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Adds an `ARCH` input variable to the Hyper download recipe, allowing users to specify which architecture to download:

- `dmg` — Intel (default, preserves current behavior)
- `dmg_arm64` — Apple Silicon

The download URL is updated from the hardcoded `https://releases.hyper.is/download/mac` to `https://releases.hyper.is/download/%ARCH%`.

Both values verified with `autopkg run -vvq`:

**Intel (`-k ARCH=dmg`)** — downloads and passes code signature verification:
```
URLDownloader: Downloaded .../Hyper.dmg
  url: https://releases.hyper.is/download/dmg
CodeSignatureVerifier: Signature is valid
```

**Apple Silicon (`-k ARCH=dmg_arm64`)** — downloads and passes code signature verification:
```
URLDownloader: Downloaded .../Hyper.dmg
  url: https://releases.hyper.is/download/dmg_arm64
CodeSignatureVerifier: Signature is valid
```