### PR TITLE
Deprecate Balena Etcher recipes

### DIFF
--- a/Etcher-CLI/Etcher-CLI.download.recipe
+++ b/Etcher-CLI/Etcher-CLI.download.recipe
@@ -14,9 +14,18 @@
 		<string>balena-etcher-cli</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Balena Etcher developer signing certificate was revoked by Apple, and the developer has not explained why. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>

--- a/Etcher/Etcher.download.recipe
+++ b/Etcher/Etcher.download.recipe
@@ -14,9 +14,18 @@
 		<string>balenaEtcher</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>The Balena Etcher developer signing certificate was revoked by Apple, and the developer has not explained why. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
## Summary
- Add `DeprecationWarning` processor as the first step in both `Etcher/Etcher.download.recipe` and `Etcher-CLI/Etcher-CLI.download.recipe`
- Update `MinimumVersion` from `1.0.0` to `1.1` (required for DeprecationWarning support)
- The Balena Etcher developer signing certificate was revoked by Apple, and the developer has not explained why, making these recipes a security concern

Closes #71

## Test plan
- [ ] Run `autopkg verify-trust-info Etcher.download` and confirm the DeprecationWarning is displayed
- [ ] Run `autopkg verify-trust-info Etcher-CLI.download` and confirm the DeprecationWarning is displayed
- [ ] Verify that both recipe files are valid XML/plist format

🤖 Generated with [Claude Code](https://claude.com/claude-code)