### PR TITLE
Update PocketCasts code signature requirements

### DIFF
--- a/PocketCasts/PocketCasts.download.recipe
+++ b/PocketCasts/PocketCasts.download.recipe
@@ -56,7 +56,7 @@
 				<key>input_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%/%APP_NAME%.app</string>
 				<key>requirement</key>
-				<string>anchor apple generic and identifier "au.com.shiftyjelly.PocketCasts" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = U92XK6M46K)</string>
+				<string>anchor apple generic and identifier "au.com.shiftyjelly.PocketCastsMac" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = PZYM8XX95Q)</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
## Summary
- Update the `CodeSignatureVerifier` requirement in `PocketCasts.download.recipe` to reflect the app's new bundle identifier (`au.com.shiftyjelly.PocketCastsMac`) and new team OU (`PZYM8XX95Q`).
- Closes #53

## Test plan
- [ ] Run `autopkg run PocketCasts.download` and verify CodeSignatureVerifier passes with the updated identifier and team OU.
- [ ] Confirm the downloaded app's code signature matches the new requirement string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)