### PR TITLE
Deprecate BitBar recipes

### DIFF
--- a/bitbar/bitbar.download.recipe
+++ b/bitbar/bitbar.download.recipe
@@ -12,9 +12,18 @@
 		<string>BitBar</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.9</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>BitBar has been renamed to xbar (https://github.com/matryer/xbar), but xbar has not been updated since 2021 and remains in perpetual beta. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
 		<dict>
 			<key>Processor</key>
 			<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
## Summary

- Add `DeprecationWarning` processor as the first step in `bitbar/bitbar.download.recipe`, since BitBar has been renamed to xbar but xbar has not been updated since 2021 and remains in perpetual beta.
- Update `MinimumVersion` from `0.2.9` to `1.1` (required for `DeprecationWarning` support).

Closes #45

## Test plan

- [ ] Verify `bitbar.download.recipe` parses correctly with `plutil -lint bitbar/bitbar.download.recipe`
- [ ] Run the recipe with AutoPkg and confirm the `DeprecationWarning` message is displayed
- [ ] Confirm child recipes (e.g., `bitbar.munki.recipe`) inherit the deprecation warning from the parent download recipe

🤖 Generated with [Claude Code](https://claude.com/claude-code)