### PR TITLE
Add ARCH input variable to Kodi download recipe

### DIFF
--- a/kodi/kodi.download.recipe
+++ b/kodi/kodi.download.recipe
@@ -3,17 +3,25 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest release version of Kodi. The .app bundle is not code-signed.</string>
+	<string>Downloads the latest release version of Kodi. The .app bundle is not code-signed.
+
+Use the ARCH input variable to specify the architecture to download.
+Values at the time of writing are:
+
+- arm64 (Apple Silicon, default)
+- x86_64 (Intel)</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.download.kodi</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>arm64</string>
 		<key>NAME</key>
 		<string>Kodi</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://kodi.tv/download/851/</string>
+		<string>https://mirrors.kodi.tv/releases/osx/%ARCH%/</string>
 		<key>SEARCH_PATTERN</key>
-		<string>[^"]+\.dmg[^"?]*</string>
+		<string>kodi-[\d.]+-[A-Za-z]+-%ARCH%\.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>


### PR DESCRIPTION
## Summary

- Switches the Kodi download recipe from `kodi.tv/download/851/` (broken due to Cloudflare protection) to the browseable Kodi mirrors directory at `https://mirrors.kodi.tv/releases/osx/%ARCH%/`.
- Adds an `ARCH` input variable (default `arm64`) so users can choose between `arm64` (Apple Silicon) and `x86_64` (Intel) builds.
- Updates the `SEARCH_PATTERN` to match only stable releases (e.g., `kodi-21.3-Omega-arm64.dmg`), filtering out beta and RC builds that contain underscores.

Closes #78

## Test plan

- [ ] Run the recipe with default ARCH (arm64) and verify it downloads the latest stable Kodi DMG for Apple Silicon
- [ ] Run the recipe with `-k ARCH=x86_64` and verify it downloads the latest stable Kodi DMG for Intel
- [ ] Confirm beta/RC builds (e.g., `kodi-21.0-Omega_beta1-arm64.dmg`) are not matched by the search pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)