### PR TITLE
Add ARCH variable to Kodi download

### DIFF
--- a/kodi/kodi.download.recipe
+++ b/kodi/kodi.download.recipe
@@ -3,17 +3,25 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest release version of Kodi. The .app bundle is not code-signed.</string>
+	<string>Downloads the latest release version of Kodi. The .app bundle is not code-signed.
+
+Use the ARCH input variable to specify the architecture to download.
+Values at the time of writing are:
+
+- x86_64 (Intel, default)
+- arm64 (Apple Silicon)</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.download.kodi</string>
 	<key>Input</key>
 	<dict>
+		<key>ARCH</key>
+		<string>x86_64</string>
 		<key>NAME</key>
 		<string>Kodi</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://kodi.tv/download/851/</string>
+		<string>https://mirrors.kodi.tv/releases/osx/%ARCH%/</string>
 		<key>SEARCH_PATTERN</key>
-		<string>[^"]+\.dmg[^"?]*</string>
+		<string>kodi-[\d.]+-[A-Za-z]+-%ARCH%\.dmg</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
@@ -36,7 +44,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>%match%</string>
+				<string>%DOWNLOAD_URL%%match%</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Adds an ARCH input variable to the Kodi download recipe (default: x86_64). Switches from the Cloudflare-protected kodi.tv page to the mirrors.kodi.tv directory listing, which is directly accessible. The existing recipe is broken — `kodi.tv/download/851/` no longer contains DMG links.

Closes #78

<details><summary>Before: autopkg run -vv output (broken)</summary>

```
% autopkg run -vv kodi/kodi.download.recipe
Processing kodi/kodi.download.recipe...
URLTextSearcher
{'Input': {'re_pattern': '[^"]+\\.dmg[^"?]*',
           'url': 'https://kodi.tv/download/851/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match

The following recipes failed:
    kodi/kodi.download.recipe
        Error in com.github.andrewvalentine.download.kodi: Processor: URLTextSearcher: Error: No match found on URL: https://kodi.tv/download/851/
```

</details>

<details><summary>After: autopkg run -vv output</summary>

```
% autopkg run -vv kodi/kodi.download.recipe
Processing kodi/kodi.download.recipe...
URLTextSearcher
{'Input': {'re_pattern': 'kodi-[\\d.]+-[A-Za-z]+-x86_64\\.dmg',
           'url': 'https://mirrors.kodi.tv/releases/osx/x86_64/'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (match): kodi-21.3-Omega-x86_64.dmg
{'Output': {'match': 'kodi-21.3-Omega-x86_64.dmg'}}
URLDownloader
{'Input': {'url': 'https://mirrors.kodi.tv/releases/osx/x86_64/kodi-21.3-Omega-x86_64.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.kodi/downloads/kodi-21.3-Omega-x86_64.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.kodi/downloads/kodi-21.3-Omega-x86_64.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
```

</details>