### PR TITLE
Update BitBar recipes for xbar rename

### DIFF
--- a/bitbar/bitbar.download.recipe
+++ b/bitbar/bitbar.download.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest release version of BitBar from Github</string>
+	<string>Downloads the latest release version of xbar (formerly BitBar) from Github.</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.download.bitbar</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>BitBar</string>
+		<string>xbar</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>github_repo</key>
-				<string>matryer/bitbar</string>
+				<string>matryer/xbar</string>
 				<key>include_prereleases</key>
 				<false/>
 			</dict>
@@ -35,10 +35,20 @@
 				<string>%url%</string>
 			</dict>
 		</dict>
-		<!-- Code signature verification not possible -->
 		<dict>
 			<key>Processor</key>
 			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/xbar.app</string>
+				<key>requirement</key>
+				<string>identifier "com.xbarapp.app" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "N3H5B92L5N"</string>
+			</dict>
 		</dict>
 	</array>
 </dict>

--- a/bitbar/bitbar.install.recipe
+++ b/bitbar/bitbar.install.recipe
@@ -3,44 +3,42 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads and installs the latest release version of BitBar</string>
+	<string>Downloads and installs the latest release version of xbar (formerly BitBar).</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.install.bitbar</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>BitBar</string>
-    </dict>
-    <key>MinimumVersion</key>
-    <string>0.2.9</string>
-    <key>ParentRecipe</key>
-    <string>com.github.andrewvalentine.download.bitbar</string>
-    <key>Process</key>
-    <array>
-        <dict>
-            <key>Processor</key>
-            <string>Unarchiver</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>Copier</string>
-            <key>Arguments</key>
-            <dict>
-                <key>destination_path</key>
-                <string>/Applications/BitBar.app</string>
-                <key>source_path</key>
-                <string>%RECIPE_CACHE_DIR%/downloads/BitBar.app</string>
-            </dict>
-        </dict>
-        <dict>
-            <key>Processor</key>
-            <string>EndOfCheckPhase</string>
-        </dict>
-    </array>
+		<string>xbar</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>0.2.9</string>
+	<key>ParentRecipe</key>
+	<string>com.github.andrewvalentine.download.bitbar</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>InstallFromDMG</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_path</key>
+				<string>%pathname%</string>
+				<key>items_to_copy</key>
+				<array>
+					<dict>
+						<key>source_item</key>
+						<string>xbar.app</string>
+						<key>destination_path</key>
+						<string>/Applications</string>
+					</dict>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/bitbar/bitbar.munki.recipe
+++ b/bitbar/bitbar.munki.recipe
@@ -3,15 +3,15 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads and imports the current release version of BitBar into Munki</string>
+	<string>Downloads and imports the current release version of xbar (formerly BitBar) into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.munki.bitbar</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>BitBar</string>
+		<string>xbar</string>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string>apps/bitbar</string>
+		<string>apps/xbar</string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -21,11 +21,11 @@
 			<key>category</key>
 			<string>Utilities</string>
 			<key>description</key>
-			<string>BitBar lets you put the output from any script or program right in your Mac OS X menu bar.</string>
+			<string>xbar (formerly BitBar) lets you put the output from any script or program right in your macOS menu bar.</string>
 			<key>developer</key>
 			<string>Mat Ryer</string>
 			<key>display_name</key>
-			<string>BitBar</string>
+			<string>xbar</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>unattended_install</key>
@@ -40,31 +40,11 @@
 	<array>
 		<dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
-			<key>Arguments</key>
-			<dict>
-				<key>destination_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>DmgCreator</string>
-			<key>Arguments</key>
-			<dict>
-				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/BitBar.app</string>
-				<key>dmg_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
-			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
 			<string>MunkiImporter</string>
 			<key>Arguments</key>
 			<dict>
 				<key>pkg_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
+				<string>%pathname%</string>
 				<key>repo_subdirectory</key>
 				<string>%MUNKI_REPO_SUBDIR%</string>
 			</dict>

--- a/bitbar/bitbar.pkg.recipe
+++ b/bitbar/bitbar.pkg.recipe
@@ -3,13 +3,13 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Create a package from the BitBar download</string>
+	<string>Downloads xbar (formerly BitBar) and creates a package.</string>
 	<key>Identifier</key>
 	<string>com.github.andrewvalentine.pkg.bitbar</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
-		<string>BitBar</string>
+		<string>xbar</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.9</string>
@@ -33,27 +33,13 @@
 		</dict>
 		<dict>
 			<key>Processor</key>
-			<string>Unarchiver</string>
+			<string>Copier</string>
 			<key>Arguments</key>
 			<dict>
+				<key>source_path</key>
+				<string>%pathname%/xbar.app</string>
 				<key>destination_path</key>
-				<string>%pkgroot%/Applications/</string>
-			</dict>
-		</dict>
-		<dict>
-		<key>Processor</key>
-		<string>PlistReader</string>
-		<key>Arguments</key>
-			<dict>
-				<key>info_path</key>
-				<string>%pkgroot%/Applications/BitBar.app/Contents/Info.plist</string>
-				<key>plist_keys</key>
-				<dict>
-					<key>CFBundleShortVersionString</key>
-					<string>version</string>
-					<key>CFBundleIdentifier</key>
-					<string>identifier</string>
-				</dict>
+				<string>%pkgroot%/Applications/xbar.app</string>
 			</dict>
 		</dict>
 		<dict>
@@ -68,7 +54,7 @@
 					<key>pkgname</key>
 					<string>%NAME%</string>
 					<key>id</key>
-					<string>%identifier%</string>
+					<string>com.xbarapp.app</string>
 					<key>version</key>
 					<string>%version%</string>
 					<key>chown</key>


### PR DESCRIPTION
Updates all BitBar recipes to work with xbar (the BitBar successor). Changes include updating the GitHub repo from `matryer/bitbar` to `matryer/xbar`, adding CodeSignatureVerifier (xbar is signed, BitBar was not), switching child recipes from ZIP-based Unarchiver to DMG-based handling, and updating all app name references from BitBar to xbar. The pkg recipe uses `%version%` from GitHubReleasesInfoProvider rather than reading the app's Info.plist, which has a non-standard format that autopkg's plist parser rejects.

Closes #45

<details><summary>After: autopkg run -vv output (download and pkg)</summary>

```
% autopkg run -vv bitbar/bitbar.download.recipe bitbar/bitbar.pkg.recipe
Processing bitbar/bitbar.download.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'matryer/xbar', 'include_prereleases': False}}
GitHubReleasesInfoProvider: Fetching page 1 of GitHub releases
GitHubReleasesInfoProvider: Selected asset 'xbar.v2.1.7-beta.dmg' from release 'v2.1.7-beta'
{'Output': {'url': 'https://github.com/matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg',
            'version': '2.1.7-beta'}}
URLDownloader
{'Input': {'url': 'https://github.com/matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg'}}
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.bitbar/downloads/xbar.v2.1.7-beta.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.bitbar/downloads/xbar.v2.1.7-beta.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.bitbar/downloads/xbar.v2.1.7-beta.dmg/xbar.app',
           'requirement': 'identifier "com.xbarapp.app" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"N3H5B92L5N"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.andrewvalentine.download.bitbar/downloads/xbar.v2.1.7-beta.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: /private/tmp/dmg.V0zezx/xbar.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.V0zezx/xbar.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.V0zezx/xbar.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Processing bitbar/bitbar.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'matryer/xbar', 'include_prereleases': False}}
GitHubReleasesInfoProvider: Selected asset 'xbar.v2.1.7-beta.dmg' from release 'v2.1.7-beta'
{'Output': {'url': 'https://github.com/matryer/xbar/releases/download/v2.1.7-beta/xbar.v2.1.7-beta.dmg',
            'version': '2.1.7-beta'}}
URLDownloader
URLDownloader: Item at URL is unchanged.
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.bitbar/downloads/xbar.v2.1.7-beta.dmg'}}
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Signature is valid
PkgRootCreator
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.bitbar/xbar
Copier
Copier: Copied /private/tmp/dmg.0GIZM9/xbar.app to ~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.bitbar/xbar/Applications/xbar.app
PkgCreator
{'Output': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.bitbar/xbar.pkg'}}

The following packages were built:
    Identifier       Version     Pkg Path
    ----------       -------     --------
    com.xbarapp.app  2.1.7-beta  ~/Library/AutoPkg/Cache/com.github.andrewvalentine.pkg.bitbar/xbar.pkg
```

</details>